### PR TITLE
Support for explicit IP addresses to filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ When downloading the databases the last-modified datetime is queried and saved. 
 | COUNTRY_DIR | The directory inside the container that the country database file is saved to.</br>Default value `LASTMODIFIED_DIR/country`| `/path/foldername`      |
 | SUB_DIR | The directory inside the container that the subdivision database file is saved to.</br>Default value `LASTMODIFIED_DIR/sub`| `/path/foldername`      |
 | IPLIST_FILENAME | The filename of the configuration file containing the filter list. </br> Default value `IPList.conf` | `filename.conf` |
+| EXTRA_IPS | Additional IP addresses/ranges to append to the filter list. | `10.0.0.0/8 172.16.0.0/12 192.168.0.0/16` |
 <br>
 
 ## Formatting ISO 3166 codes and place names

--- a/geoip-filter.sh
+++ b/geoip-filter.sh
@@ -207,9 +207,11 @@ sub_addIPsToIPList() {
 }
 
 extra_addIPsToIPList() {
-  echo "  Adding Extra IPs to ${ipListFilename}."
-  echo "    #Extra IPs" >> ${ipListFilePath}
-  printf '    "%s" 1;\n' "${extraIPs[@]}" >> "${ipListFilePath}"
+  if (($#)); then
+    echo "  Adding Extra IPs to ${ipListFilename}."
+    echo "    #Extra IPs" >> ${ipListFilePath}
+    printf '    "%s" 1;\n' "$@" >> "${ipListFilePath}"
+  fi
 }
 
 getLastModifiedArray=(country_getLastModified sub_getLastModified)

--- a/geoip-filter.sh
+++ b/geoip-filter.sh
@@ -8,6 +8,7 @@ maxMindLicenceKey=${MAXMIND_KEY}
 filterType="${FILTER_TYPE,,}"
 countryCodes=($COUNTRY_CODES)
 subCodes=($SUB_CODES)
+extraIPs=($EXTRA_IPS)
 searchMode="${SEARCH_MODE,,:-"false"}"
 allowStatusCode=${ALLOW_STATUS_CODE:-"200"}
 blockStatusCode=${BLOCK_STATUS_CODE:-"404"}
@@ -205,6 +206,12 @@ sub_addIPsToIPList() {
   fi
 }
 
+extra_addIPsToIPList() {
+  echo "  Adding Extra IPs to ${ipListFilename}."
+  echo "    #Extra IPs" >> ${ipListFilePath}
+  printf '    "%s" 1;\n' "${extraIPs[@]}" >> "${ipListFilePath}"
+}
+
 getLastModifiedArray=(country_getLastModified sub_getLastModified)
 getZipArray=(country_getZip sub_getZip)
 
@@ -249,6 +256,7 @@ writeIpList() {
   startIpListFile
   country_loop "${countryCodes[@]}"
   sub_loop "${subCodes[@]}"
+  extra_addIPsToIPList "${extraIPs[@]}"
   endIpListFile
 }
 


### PR DESCRIPTION
Quick and dirty way to let one or two hosts through the filter (or, as in the example, allow all LAN traffic).