### PR TITLE
Strip all headers except X-Forwarded-For

### DIFF
--- a/geoip-filter.sh
+++ b/geoip-filter.sh
@@ -272,6 +272,11 @@ server {
     listen ${listenPort};
 
     location /traefik {
+        proxy_pass_request_headers off;
+        proxy_set_header X-Forwarded-For \$http_x_forwarded_for;
+        proxy_pass http://127.0.0.1:${listenPort}/internal;
+    }
+    location /internal {
         add_header Content-Type "default_type text/plain";
         if (\$inIPList = 1) {
             return ${filterStatusCode};


### PR DESCRIPTION
This ensures that nothing but the client IP can affect the response. Previously some request headers caused 304 and 412 responses.

Fixes #75 and passes their test cases:
```
200 OK (plain request)                        → 200
200 OK (If-Modified-Since)                    → 200
304 Not Modified (If-None-Match: *)           → 200
412 Precondition Failed (If-Match)            → 200
412 Precondition Failed (If-Unmodified-Since) → 200
403 X-Forwarded-For France is Blocked         → 403
```